### PR TITLE
Fix typo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ To use your local changes from the `kubenav-plugin` in the kubenav app change th
 
 ```diff
   "dependencies": {
--    "kubenav-plugin": "1.0.0",
-+    "kubenav-plugin": "file:../kubenav-plugin",
+-    "@kubenav/kubenav-plugin": "1.0.0",
++    "@kubenav/kubenav-plugin": "file:../kubenav-plugin",
   }
 ```
 


### PR DESCRIPTION
We used `kubenav-plugin` as package for testing, but for production we are using `@kubenav/kubenav-plugin`. The prefix `@kubenav` is needed since we are using the GitHub Package registry for the NPM Package.