### PR TITLE
Fix files list for the published NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dist/",
     "ios/",
     "android/",
-    "KubenavPlugin.podspec"
+    "KubenavKubenavPlugin.podspec"
   ],
   "keywords": [
     "capacitor",


### PR DESCRIPTION
In the last PR we changed the filename of the `.podspec` file from `KubenavPlugin` to `KubenavKubenavPlugin`, but forgot to change the files list in the `package.json` file. Therefor the file was not in the published NPM package.