### PR TITLE
Add cluster option to request function

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -7,5 +7,5 @@ declare module "@capacitor/core" {
 export interface KubenavPluginPlugin {
   awsGetClusters(options: { accessKeyId: string, secretAccessKey: string, region: string }): Promise<{data: string}>;
   awsGetToken(options: { accessKeyId: string, secretAccessKey: string, region: string, clusterID: string }): Promise<{data: string}>;
-  request(options: { server: string, method: string, url: string, body: string, certificateAuthorityData: string, clientCertificateData: string, clientKeyData: string, token: string, username: string, password: string }): Promise<{data: string}>;
+  request(options: { server: string, cluster: string, method: string, url: string, body: string, certificateAuthorityData: string, clientCertificateData: string, clientKeyData: string, token: string, username: string, password: string }): Promise<{data: string}>;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -17,7 +17,7 @@ export class KubenavPluginWeb extends WebPlugin implements KubenavPluginPlugin {
     throw new Error(`This feature is not implemented for web, options: ${JSON.stringify(options)}`);
   };
 
-  async request(options: { server: string, method: string, url: string, body: string, certificateAuthorityData: string, clientCertificateData: string, clientKeyData: string, token: string, username: string, password: string }): Promise<{data: string}> {
+  async request(options: { server: string, cluster: string, method: string, url: string, body: string, certificateAuthorityData: string, clientCertificateData: string, clientKeyData: string, token: string, username: string, password: string }): Promise<{data: string}> {
     let response = await fetch(`${options.server}/request`, {
       method: 'POST',
       headers: {
@@ -25,6 +25,7 @@ export class KubenavPluginWeb extends WebPlugin implements KubenavPluginPlugin {
         'Accept': 'application/json',
       },
       body: JSON.stringify({
+        cluster: options.cluster,
         method: options.method,
         url: options.url,
         body: options.body,


### PR DESCRIPTION
Add a new parameter 'cluster' to the options for the request function, which can be used by the desktop implementation of kubenav to interact with the correct cluster in a kubeconfig file.