### PR TITLE
Do not use latest Capacitor version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,29 +5,29 @@
   "requires": true,
   "dependencies": {
     "@capacitor/android": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-1.4.0.tgz",
-      "integrity": "sha512-J+QosCfRFw6sm8j/g0RAMwM9B01oMbRcbss6HkSggPe3OqDm+hdSDjNzU7BHDnRxnSlucb5N6xmGuXz2u7/piA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-1.5.2.tgz",
+      "integrity": "sha512-pJOFjYgpuVMSN0Bm+Ndkyf/xuMwRDPx3jtz/5xCbypM1tf6W75tqV+z5ABLhKySx8Bo+b/t7xDKwRG7+PEUwWQ==",
       "dev": true
     },
     "@capacitor/core": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-1.4.0.tgz",
-      "integrity": "sha512-9cLk6f8A2BjSh9KTItAOXGFSS9ZsVReMUACWw+1lEHsSk5kdPbp0oQ8c1kOX36LlHeBKi/EPSs8dXNedNHyHQA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-1.5.2.tgz",
+      "integrity": "sha512-0UPJUzwVrPM4YY4BPLr6oypmn8FYF7iaOYujAtUtOfQjuoAvg7c5DKdZ8LOQtsuG6JqsIsTcqZ6w8nGQQ+g0YQ==",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@capacitor/ios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-1.4.0.tgz",
-      "integrity": "sha512-vauJj/ye7d9cHPeLWHHS+sk+5V+Cgw8hhEzzYIxuwJ0t0HRIq9jnsJ+U9FF6Z2wphfX5jRFatfAxLxFLOmKGFg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-1.5.2.tgz",
+      "integrity": "sha512-LD6TDnxIGkCm5LEEe/8EuOSmiOTKxZ+fuzFgPlKyKqNEKrR+wcALOBB+Uq9WrWtq0BmU39p3OwRfhjCJxf5m1g==",
       "dev": true
     },
     "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
     },
     "typescript": {
       "version": "3.7.4",

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "registry": "https://npm.pkg.github.com/@kubenav"
   },
   "dependencies": {
-    "@capacitor/core": "latest"
+    "@capacitor/core": "^1.5.0"
   },
   "devDependencies": {
     "typescript": "^3.2.4",
-    "@capacitor/ios": "latest",
-    "@capacitor/android": "latest"
+    "@capacitor/ios": "^1.5.0",
+    "@capacitor/android": "^1.5.0"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
Capacitor 2 was released and was used in the NPM package. Since we don't want to update kubenav to Capacitor 2 yet, we have to pin the used Capacitor version.

When the plugin uses Capacitor 2 the `registerPlugins` function returns an error.